### PR TITLE
 'this' is not allowed before super() fix.

### DIFF
--- a/src/monads.js
+++ b/src/monads.js
@@ -41,6 +41,7 @@ export class Option {
 
 export class Some extends Option {
     constructor(value) {
+        super();
         this._value = value;
     }
     fold(some, none) {


### PR DESCRIPTION
related thread from babel https://github.com/babel/babel/issues/1131
